### PR TITLE
Ability to install and execute the command globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ It currently supports a few options:
 ```
 
 Running the script with no options will give you vanilla Lorem Ipsum
+
+## Installation
+
+```bash
+npm install clipsum -g
+```

--- a/app.js
+++ b/app.js
@@ -22,3 +22,4 @@ else{
   clip.copy('Lorem ipsum dolor sit amet, elit purus eros id vitae sed blandit. Risus dui dui, vel vehicula erat sem, aliquam veniam leo. Suspendisse mauris dolor vestibulum enim feugiat, leo mauris consequat eu eget, adipiscing vestibulum et tellus, nec laoreet non metus eget.');
 }
 
+process.exit();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipsum",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "lorem ipsum command line interface",
   "main": "app.js",
   "scripts": {
@@ -19,5 +19,8 @@
   "dependencies": {
     "commander": "^2.5.0",
     "copy-paste": "^1.0.1"
+  },
+  "bin": {
+    "clipsum": "./app.js"
   }
 }


### PR DESCRIPTION
Hi @aclarkk !

It seems I've stumbled on your project after having a similar idea for a minimalist Lorem ipsum-to-the-clipboard node script and coincidentally was going to name it `clipsum` as well. 

Not sure if you are still maintaining this project, but if so and you agree with these changes, I've added the following functionality:
- Ability to install and execute it globally via the `clipsum` command as opposed to directly executing the script file.
- Process exiting so it doesn't hang after execution.
- `.gitgnore` in the package to keep `node_modules` from getting in there.

Thanks,
Pat